### PR TITLE
Add feature: Set/specify NTP query source host IP or/and port

### DIFF
--- a/lib/net/ntp/ntp.rb
+++ b/lib/net/ntp/ntp.rb
@@ -63,8 +63,9 @@ module Net #:nodoc:
     ###
     # Sends an NTP datagram to the specified NTP server and returns
     # a hash based upon RFC1305 and RFC2030.
-    def self.get(host="pool.ntp.org", port="ntp", timeout=TIMEOUT)
+    def self.get(host="pool.ntp.org", port="ntp", timeout=TIMEOUT, src_host="0.0.0.0", src_port=0)
       sock = UDPSocket.new
+      sock.bind(src_host, src_port)
       sock.connect(host, port)
 
       client_localtime      = Time.now.to_f


### PR DESCRIPTION
This adds the ability to specify a source host IP or/and port for NTP queries.